### PR TITLE
fix: metrics sum is white and isn't visible

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_API_STAC_ENDPOINT='https://earth.gov/ghgcenter/api/stac'
 NEXT_PUBLIC_API_RASTER_ENDPOINT='https://earth.gov/ghgcenter/api/raster'
-NEXT_PUBLIC_BASE_PATH='/ghgcenter'
+# NEXT_PUBLIC_BASE_PATH='/ghgcenter'
 NEXT_PUBLIC_PORTAL_URL='https://earth.gov/ghgcenter/'
 DOMAIN_PROD='https://earth.gov'
 NEXT_USE_DRUPAL_API=true

--- a/app/store/providers/theme.tsx
+++ b/app/store/providers/theme.tsx
@@ -28,8 +28,9 @@ const VEDA_OVERRIDE_THEME = {
     infographicA: '#fcab10',
     infographicB: '#f4442e',
     infographicC: '#b62b6e',
-    infographicD: '#2ca58d',
+    infographicD: '#8a54525b',
     infographicE: '#2276ac',
+    infographicF: '#28730d'
   },
   type: {
     base: {

--- a/app/store/providers/theme.tsx
+++ b/app/store/providers/theme.tsx
@@ -28,9 +28,9 @@ const VEDA_OVERRIDE_THEME = {
     infographicA: '#fcab10',
     infographicB: '#f4442e',
     infographicC: '#b62b6e',
-    infographicD: '#8a54525b',
+    infographicD: '#8a54525b', // translucent for std dev
     infographicE: '#2276ac',
-    infographicF: '#28730d'
+    infographicF: '#28730d' //sum
   },
   type: {
     base: {


### PR DESCRIPTION
# Description
Add theme color corresponding to the "sum" metrics in analytics metrics (previously it didn't exist and so it defaulted to white). Also changed std dev to not clash colors.